### PR TITLE
Changed the Altar's spawn group to fix Z-Buffer location

### DIFF
--- a/src/ready.lua
+++ b/src/ready.lua
@@ -112,7 +112,7 @@ function mod.SpawnAltar()
 		altar.OnUsedFunctionName = _PLUGIN.guid .. '.' .. 'OpenAltarMenu'
 		altar.ObjectId = SpawnObstacle({
 			Name = "GiftRack",
-			Group = "FX_Terrain",
+			Group = "Standing",
 			DestinationId = spawnId,
 			AttachedTable =
 				altar,


### PR DESCRIPTION
`FX_Terrain` adds the Altar to the terrain group, which causes it to be drawn beneath other textures. `Standing` makes it a "higher priority" in the Z-Buffer and fixes the rendering, while not changing the intractability.
Before: 
![before](https://github.com/user-attachments/assets/e69e685f-64fc-41a9-bc1c-5d5b59dc176c)
After: 
![after](https://github.com/user-attachments/assets/bd9db215-1056-423b-9b8b-fe73b39406a0)
