### PR TITLE
Updated ready.lua and README for Nightmare Fear compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added Nightmare Fear compatibility
+
 ## [0.6.1] - 2025-10-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ For Selene, selecting her also grants you the additional path of star points the
 ### Additional features
 
 You can force Chaos, Selene, Artemis and Athena, to spawn like regular gods. Some can only appear in certain biomes or have special requirements like vanilla however.
+
+If Nightmare Fear is installed, Selene, Artemis and Athena will not be able to be selected depending on whether the Vows of Isolation and Eclipse are invoked.

--- a/src/ready.lua
+++ b/src/ready.lua
@@ -292,6 +292,27 @@ function mod.OpenAltarMenu()
 					OffsetY = offsetY,
 					Duration = delay
 				})
+				if (upgradeName == "NPC_Athena_01" or upgradeName == "NPC_Artemis_01") and GetNumShrineUpgrades("NightmareFearNoHelpMetaUpgrade") >= 1 then
+					components[buttonKey].OnPressedFunctionName = "BlockedKeepsakePresentation"
+					SetColor({ Id = components[buttonKey].Image, Color = Color.Black, Duration = 0 })
+					CreateTextBox({ 
+					Id = components[buttonKey].Id,
+					Text = "BlockedByNightmareFearIsolation_Tooltip",
+					UseDescription = true,
+					OffsetX = 0, OffsetY = 0,
+					Color = Color.Transparent,
+				})
+				elseif (upgradeName == "SpellDrop") and GetNumShrineUpgrades("NightmareFearEclipseMetaUpgrade") >= 1 then
+					components[buttonKey].OnPressedFunctionName = "BlockedKeepsakePresentation"
+					SetColor({ Id = components[buttonKey].Image, Color = Color.Black, Duration = 0 })
+					CreateTextBox({ 
+					Id = components[buttonKey].Id,
+					Text = "BlockedByNightmareFearEclipse_Tooltip",
+					UseDescription = true,
+					OffsetX = 0, OffsetY = 0,
+					Color = Color.Transparent,
+				})
+				end
 			end
 		end
 	end


### PR DESCRIPTION
If you have Vow of Eclipse (no Selene) invoked, you will not be able to select Selene.

If you have Vow of Isolation (no in-run NPCs) invoked, you will not be able to select Athena or Artemis

Works by changing the OnPressedFunctionName to be BlockedKeepsakePresentation, which makes the button shake, plays a voice line and prevents you from selecting the god.

Tested to still work with and without Nightmare Fear installed